### PR TITLE
add hint about broken URLs when jupyterlab is missing in truly-minimal example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM python:3.7-slim
+# we are only installing the classic jupyter notebook, not jupyterlab
+# so you'll need to change your URLs from /lab to /tree
+# https://mybinder.readthedocs.io/en/latest/howto/user_interface.html#jupyterlab
 RUN pip install --no-cache notebook
 ENV HOME=/tmp


### PR DESCRIPTION
see https://github.com/jupyterhub/binder/issues/240