### PR TITLE
allow target path to be configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN adduser --disabled-password \
     --uid ${NB_UID} \
     ${NB_USER}
 
-# Allow target path repo is cloned to be configurable
+# allow the target path repo to be configurable
 ARG REPO_DIR=${HOME}
 ENV REPO_DIR ${REPO_DIR}
 WORKDIR ${REPO_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,11 @@ RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER}
-WORKDIR ${HOME}
+
+# Allow target path repo is cloned to be configurable
+ARG REPO_DIR=${HOME}
+ENV REPO_DIR ${REPO_DIR}
+WORKDIR ${REPO_DIR}
+RUN chown ${NB_USER}:${NB_USER} ${REPO_DIR}
+
 USER ${USER}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ENV HOME=/tmp
 
 which you can try out: [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/binder-examples/minimal-dockerfile/truly-minimal)
 
-However, it would be better to consume the NB_UID/NB_USER arguments and create a real user:
+However, it would be better to consume the NB_UID/NB_USER arguments, create a real user, and allow the target path to be configurable:
 
 ```docker
 # create user with a home directory
@@ -45,7 +45,12 @@ RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER}
-WORKDIR ${HOME}
+
+# Allow target path repo is cloned to be configurable
+ARG REPO_DIR=${HOME}
+ENV REPO_DIR ${REPO_DIR}
+WORKDIR ${REPO_DIR}
+RUN chown ${NB_USER}:${NB_USER} ${REPO_DIR}
 ```
 
 From this point, you can start adding files, installing packages, etc.


### PR DESCRIPTION
This update is handy in case one is interested to configure the target path provided via [`--target-repo-dir`](https://repo2docker.readthedocs.io/en/latest/usage.html#cmdoption-jupyter-repo2docker-target-repo-dir) for the Dockerfile usecase.

The ultimate goal might be to update the https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html and potentially repo2docker such that this becomes a requirement of the Dockerfile (a warning in case it is not satisfied).